### PR TITLE
Break out Engine time in a Class

### DIFF
--- a/lib/notis_engine/notis_engine.rb
+++ b/lib/notis_engine/notis_engine.rb
@@ -28,7 +28,6 @@ class NotisEngine
 		updateItems
 
 		return if not @currentItem
-		return if hasBeenRun?
 
 		# if we've gotten here, the current item from the current
 		# config has not yet been run
@@ -49,19 +48,6 @@ class NotisEngine
 	def updateItems
 		@items = @config.getDayItems(@engineTime.dayName)
 		@currentItem = @engineTime.currentItems(@items)
-	end
-
-	# helpers for time comparison
-	def hasBeenRun?
-		# check for day rollover
-		dayName = @timeNow.strftime('%^A')
-		if @lastTime[:day] != dayName
-			return false
-		end
-
-		hourMatch = (@currentItem.hour == @lastTime[:hour])
-		minuteMatch = (@currentItem.minute == @lastTime[:minute])
-		return (hourMatch and minuteMatch)
 	end
 
 	def showNotification

--- a/lib/notis_engine/notis_engine.rb
+++ b/lib/notis_engine/notis_engine.rb
@@ -1,9 +1,11 @@
-
+require 'notis_engine/notis_engine_time'
 
 class NotisEngine
 	def initialize(config, notification)
 		@config = config
 		@notification = notification
+
+		@engineTime = NotisEngineTime.new
 
 		@lastTime = {:day => 'SUNDAY', :hour => 0, :minute => 0}
 	end
@@ -19,7 +21,9 @@ class NotisEngine
 	private
 	def mainLoop
 		updateTime
+		@engineTime.updateTime
 		return if sameTime?
+		return if @engineTime.sameTime?
 
 		return if not updateConfig?
 
@@ -44,6 +48,7 @@ class NotisEngine
 		rescue RuntimeError
 			@notification.display("Notis Config Error")
 			setLastTime
+			@engineTime.setLastTime
 			return false
 		end
 		return true
@@ -101,6 +106,7 @@ class NotisEngine
 		level = @currentItem.level
 		@notification.display(title, body, level)
 		setLastTime
+		@engineTime.setLastTime
 	end
 end
 

--- a/lib/notis_engine/notis_engine.rb
+++ b/lib/notis_engine/notis_engine.rb
@@ -39,6 +39,7 @@ class NotisEngine
 			@config.reloadConfig
 		rescue RuntimeError
 			@notification.display("Notis Config Error")
+			# only warn about config errors once per minute
 			@engineTime.setLastTime
 			return false
 		end
@@ -47,7 +48,7 @@ class NotisEngine
 
 	def updateItems
 		@items = @config.getDayItems(@engineTime.dayName)
-		@currentItem = @engineTime.currentItems(@items)
+		@currentItem = @engineTime.currentItems(@items).first
 	end
 
 	def showNotification

--- a/lib/notis_engine/notis_engine_time.rb
+++ b/lib/notis_engine/notis_engine_time.rb
@@ -30,16 +30,16 @@ class NotisEngineTime
 
 	def currentItems(items)
 		currentItems = items.select do |item|
-			itemTimeMatch?(item, @timeNow)
+			itemTimeMatch?(item)
 		end
 		return currentItems.first
 	end
 
 	private
-	def itemTimeMatch?(item, time)
-		hourMatch = (item.hour == time.hour)
-		minuteMatch = (item.minute == time.minute)
-		hourMatch and minuteMatch
+	def itemTimeMatch?(item)
+		hourMatch = (item.hour == @timeNow.hour)
+		minuteMatch = (item.minute == @timeNow.minute)
+		return (hourMatch and minuteMatch)
 	end
 
 

--- a/lib/notis_engine/notis_engine_time.rb
+++ b/lib/notis_engine/notis_engine_time.rb
@@ -32,7 +32,7 @@ class NotisEngineTime
 		currentItems = items.select do |item|
 			itemTimeMatch?(item)
 		end
-		return currentItems.first
+		return currentItems
 	end
 
 	private

--- a/lib/notis_engine/notis_engine_time.rb
+++ b/lib/notis_engine/notis_engine_time.rb
@@ -1,0 +1,29 @@
+class NotisEngineTime
+	def initialize
+		# The last notification tracked as ran
+		@lastTime = {:day => 'SUNDAY', :hour => 0, :minute => 0}
+		puts "Engine"
+	end
+
+	def updateTime
+		@timeNow = DateTime.now
+		@dayName = @timeNow.strftime('%^A')
+		return
+	end
+
+	# is it the same time as the last time?
+	def sameTime?
+		dayMatch = (@lastTime[:day] == @dayName)
+		hourMatch = (@lastTime[:hour] == @timeNow.hour)
+		minuteMatch = (@lastTime[:minute] == @timeNow.minute)
+		dayMatch and hourMatch and minuteMatch
+	end
+
+	def setLastTime
+		@lastTime[:day] = dayName
+		@lastTime[:hour] = @timeNow.hour
+		@lastTime[:minute] = @timeNow.minute
+		return
+	end
+
+end

--- a/lib/notis_engine/notis_engine_time.rb
+++ b/lib/notis_engine/notis_engine_time.rb
@@ -1,4 +1,6 @@
 class NotisEngineTime
+	attr_reader :dayName
+
 	def initialize
 		# The last notification tracked as ran
 		@lastTime = {:day => 'SUNDAY', :hour => 0, :minute => 0}
@@ -25,5 +27,20 @@ class NotisEngineTime
 		@lastTime[:minute] = @timeNow.minute
 		return
 	end
+
+	def currentItems(items)
+		currentItems = items.select do |item|
+			itemTimeMatch?(item, @timeNow)
+		end
+		return currentItems.first
+	end
+
+	private
+	def itemTimeMatch?(item, time)
+		hourMatch = (item.hour == time.hour)
+		minuteMatch = (item.minute == time.minute)
+		hourMatch and minuteMatch
+	end
+
 
 end

--- a/lib/notis_engine/notis_engine_time.rb
+++ b/lib/notis_engine/notis_engine_time.rb
@@ -18,7 +18,7 @@ class NotisEngineTime
 		dayMatch = (@lastTime[:day] == @dayName)
 		hourMatch = (@lastTime[:hour] == @timeNow.hour)
 		minuteMatch = (@lastTime[:minute] == @timeNow.minute)
-		dayMatch and hourMatch and minuteMatch
+		return (dayMatch and hourMatch and minuteMatch)
 	end
 
 	def setLastTime


### PR DESCRIPTION
Break out the Time statefulness of the Engine into a separate class. This makes all of the time specific functions very simple and clean.

This makes the main engine code much easier to read. 

Closes #4 